### PR TITLE
Fix flaky test JsonHelperTests.testToJSONString

### DIFF
--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/JsonHelperTests.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/JsonHelperTests.java
@@ -71,6 +71,9 @@ public final class JsonHelperTests implements TestsConstants {
         val object = new FacebookObject();
         object.setId(ID);
         object.setName(NAME);
-        assertEquals("\"{\\\"id\\\":\\\"id\\\",\\\"name\\\":\\\"name\\\"}\"", JsonHelper.toJSONString(JsonHelper.toJSONString(object)));
+        String expected1 = "\"{\\\"id\\\":\\\"id\\\",\\\"name\\\":\\\"name\\\"}\"";
+        String expected2 = "\"{\\\"name\\\":\\\"name\\\",\\\"id\\\":\\\"id\\\"}\"";
+        String actual = JsonHelper.toJSONString(JsonHelper.toJSONString(object));
+        assertTrue(expected1.equals(actual) || expected2.equals(actual));
     }
 }


### PR DESCRIPTION
This PR aims to fix a test:
```
org.pac4j.oauth.profile.JsonHelperTests.testToJSONString
```
This flakiness was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

The following command can be used to replicate the failures and validate the fix:

```
mvn -pl pac4j-oauth edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.pac4j.oauth.profile.JsonHelperTests.testToJSONString
```

**Environment:**

> Java: openjdk version "17.0.9"
> Maven: Apache Maven 3.6.3

**REASON AND FIX**

The tests fail when the function `testToJSONString` returns an inconsistent order of the entries using the `JsonHelper.toJSONString()` method. JSON objects do not have a specific order, and they typically utilize Maps as their internal data structure. 

`JsonHelper.toJSONString(JsonHelper.toJSONString(object))`

where object is initialised with only ID and NAME

https://github.com/pac4j/pac4j/blob/2a7c5bf9cb96ed4a06fb0762929d4c569fe547ac/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/JsonHelperTests.java#L71-L73

In the documentation, it is mentioned as:
>This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.

Due to this, non-determinism occurs. This is solved by modifying the assert statement to expect 2 possible combinations.

https://github.com/pac4j/pac4j/blob/2a7c5bf9cb96ed4a06fb0762929d4c569fe547ac/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/JsonHelperTests.java#L77 

where expected1 and expected2 are two different combinations.
 
No user-facing change.
No dependency upgrade.

